### PR TITLE
BO-49: Added validation of events in raw stream when saving new events

### DIFF
--- a/src/BullOak.Repositories.NEventStore.Test.Integration/BullOak.Repositories.NEventStore.Test.Integration.csproj
+++ b/src/BullOak.Repositories.NEventStore.Test.Integration/BullOak.Repositories.NEventStore.Test.Integration.csproj
@@ -92,7 +92,7 @@
     <Compile Include="StepDefinitions\ReconstituteEntitySteps.cs" />
     <Compile Include="StepDefinitions\SaveStreamSteps.cs" />
     <Compile Include="StepDefinitions\ScenarioSetupAndTeardown.cs" />
-    <Compile Include="StepDefinitions\StreamSetupSteps.cs" />
+    <Compile Include="StepDefinitions\RawStreamSpecs.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\BullOak.Repositories.NEventStore\BullOak.Repositories.NEventStore.csproj">

--- a/src/BullOak.Repositories.NEventStore.Test.Integration/Specifications/SaveEventsStream.feature
+++ b/src/BullOak.Repositories.NEventStore.Test.Integration/Specifications/SaveEventsStream.feature
@@ -8,15 +8,20 @@ Scenario: Save one event in a new stream
 	And 1 new event
 	When I try to save the new events in the stream
 	Then the save process should succeed
+	And there should be 1 event in the stream
+	And there should be 1 event in the stream with Order higher or equal to 0
 
 Scenario: Save multiple events in a new stream
 	Given a new stream
 	And 3 new events
 	When I try to save the new events in the stream
 	Then the save process should succeed
+	And there should be 3 events in the stream
 
 Scenario: Save one event in an existing stream
 	Given an existing stream with 1 events
-	And 1 new event
+	And 1 new event starting with Order of 2
 	When I try to save the new events in the stream
 	Then the save process should succeed
+	And there should be 2 events in the stream
+	And there should be 1 event in the stream with Order higher or equal to 2

--- a/src/BullOak.Repositories.NEventStore.Test.Integration/Specifications/SaveEventsStream.feature.cs
+++ b/src/BullOak.Repositories.NEventStore.Test.Integration/Specifications/SaveEventsStream.feature.cs
@@ -88,6 +88,10 @@ this.ScenarioSetup(scenarioInfo);
  testRunner.When("I try to save the new events in the stream", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line 10
  testRunner.Then("the save process should succeed", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line 11
+ testRunner.And("there should be 1 event in the stream", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 12
+ testRunner.And("there should be 1 event in the stream with Order higher or equal to 0", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
             this.ScenarioCleanup();
         }
@@ -98,16 +102,18 @@ this.ScenarioSetup(scenarioInfo);
         public virtual void SaveMultipleEventsInANewStream()
         {
             TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Save multiple events in a new stream", ((string[])(null)));
-#line 12
-this.ScenarioSetup(scenarioInfo);
-#line 13
- testRunner.Given("a new stream", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
 #line 14
- testRunner.And("3 new events", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+this.ScenarioSetup(scenarioInfo);
 #line 15
- testRunner.When("I try to save the new events in the stream", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+ testRunner.Given("a new stream", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
 #line 16
+ testRunner.And("3 new events", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 17
+ testRunner.When("I try to save the new events in the stream", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line 18
  testRunner.Then("the save process should succeed", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line 19
+ testRunner.And("there should be 3 events in the stream", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
             this.ScenarioCleanup();
         }
@@ -118,16 +124,20 @@ this.ScenarioSetup(scenarioInfo);
         public virtual void SaveOneEventInAnExistingStream()
         {
             TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Save one event in an existing stream", ((string[])(null)));
-#line 18
-this.ScenarioSetup(scenarioInfo);
-#line 19
- testRunner.Given("an existing stream with 1 events", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
-#line 20
- testRunner.And("1 new event", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line 21
- testRunner.When("I try to save the new events in the stream", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+this.ScenarioSetup(scenarioInfo);
 #line 22
+ testRunner.Given("an existing stream with 1 events", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
+#line 23
+ testRunner.And("1 new event starting with Order of 2", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 24
+ testRunner.When("I try to save the new events in the stream", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line 25
  testRunner.Then("the save process should succeed", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line 26
+ testRunner.And("there should be 2 events in the stream", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 27
+ testRunner.And("there should be 1 event in the stream with Order higher or equal to 2", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
             this.ScenarioCleanup();
         }

--- a/src/BullOak.Repositories.NEventStore.Test.Integration/StepDefinitions/EventSetupSteps.cs
+++ b/src/BullOak.Repositories.NEventStore.Test.Integration/StepDefinitions/EventSetupSteps.cs
@@ -1,6 +1,8 @@
 ﻿namespace BullOak.Repositories.NEventStore.Test.Integration.StepDefinitions
 {
+    using System.Linq;
     using BullOak.Repositories.NEventStore.Test.Integration.Contexts;
+    using FluentAssertions;
     using TechTalk.SpecFlow;
 
     [Binding]
@@ -18,5 +20,10 @@
         [Given(@"(.*) new events?")]
         public void GivenNewEvent(int count)
             => eventsContainer.LastEventsCreated = generator.GenerateEvents(count);
+
+        [Given(@"(.*) new events? starting with Order of (.*)")]
+        public void GivenNewEvent(int count, int order)
+            => eventsContainer.LastEventsCreated = generator.GenerateEvents(count).Select(x =>
+                new MyEvent(x.Order + order)).ToArray();
     }
 }

--- a/src/BullOak.Repositories.NEventStore.Test.Integration/StepDefinitions/RawStreamSpecs.cs
+++ b/src/BullOak.Repositories.NEventStore.Test.Integration/StepDefinitions/RawStreamSpecs.cs
@@ -1,18 +1,20 @@
 ﻿namespace BullOak.Repositories.NEventStore.Test.Integration.StepDefinitions
 {
     using System;
+    using System.Linq;
     using BullOak.Repositories.NEventStore.Test.Integration.Contexts;
+    using FluentAssertions;
     using global::NEventStore;
     using TechTalk.SpecFlow;
 
     [Binding]
-    internal class StreamSetupSteps
+    internal class RawStreamSpecs
     {
         private EventGenerator eventGenerator;
         private StreamInfoContainer streamInfo;
         private NEventStoreContainer neventStoreContainer;
 
-        public StreamSetupSteps(EventGenerator eventGenerator, StreamInfoContainer streamInfo, NEventStoreContainer neventStoreContainer)
+        public RawStreamSpecs(EventGenerator eventGenerator, StreamInfoContainer streamInfo, NEventStoreContainer neventStoreContainer)
         {
             this.eventGenerator = eventGenerator;
             this.streamInfo = streamInfo;
@@ -48,6 +50,30 @@
                 }
 
                 stream.CommitChanges(Guid.NewGuid());
+            }
+        }
+
+        [Then(@"there should be (.*) events? in the stream")]
+        public void ThenThereShouldBeEventInTheStream(int expectedEventCount)
+        {
+            using (var stream = neventStoreContainer.OpenStream(streamInfo.Id, streamInfo.Revision))
+            {
+                stream.CommittedEvents.Count.Should().Be(expectedEventCount);
+            }
+        }
+
+        [Then(@"there should be (.*) events? in the stream with Order higher or equal to (.*)")]
+        public void ThenThereShouldBeEventInTheStreamWithHighOrderOf(int expectedEventCount, int minimumOrder)
+        {
+            using (var stream = neventStoreContainer.OpenStream(streamInfo.Id, streamInfo.Revision))
+            {
+                stream.CommittedEvents
+                    .Where(x => x.Body is MyEvent)
+                    .Select(x => x.Body)
+                    .Cast<MyEvent>()
+                    .Where(x => x.Order >= minimumOrder)
+                    .Count()
+                    .Should().Be(expectedEventCount);
             }
         }
     }


### PR DESCRIPTION
Fixes #49

Work done
---

Added validations of raw stream data to serve better isolation and discoverability of issues regarding storing events in stream

- SaveEventStream.feature in BullOak.Repositories.NEventStore.Integration.Test
- EventSetupSteps.cs in same project