### PR TITLE
BO-52: Fix concurrency on configuration.

### DIFF
--- a/src/BullOak.Repositories.Test.Acceptance/Properties/AssemblyInfo.cs
+++ b/src/BullOak.Repositories.Test.Acceptance/Properties/AssemblyInfo.cs
@@ -35,5 +35,3 @@ using Xunit;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
-
-[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/src/BullOak.Repositories/BullOak.Repositories.csproj
+++ b/src/BullOak.Repositories/BullOak.Repositories.csproj
@@ -11,7 +11,7 @@
     <PackageProjectUrl>https://github.com/BullOak/BullOak</PackageProjectUrl>
     <RepositoryUrl>https://github.com/BullOak/BullOak</RepositoryUrl>
     <PackageTags>CQRS EventStourcing event-driven repository repositories DDD domain-driven-design</PackageTags>
-    <Version>1.1.0</Version>
+    <Version>1.1.1</Version>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <FileVersion>1.0.0.0</FileVersion>
   </PropertyGroup>

--- a/src/BullOak.Repositories/Session/BaseRepoSession.cs
+++ b/src/BullOak.Repositories/Session/BaseRepoSession.cs
@@ -4,7 +4,6 @@
     using System.Collections;
     using System.Collections.Generic;
     using System.Linq;
-    using System.Security.Cryptography.X509Certificates;
     using System.Threading;
     using System.Threading.Tasks;
     using BullOak.Repositories.Appliers;
@@ -25,8 +24,7 @@
         protected readonly IPublishEvents eventPublisher;
 
         private static readonly Type stateType = typeof(TState);
-        private static object eventApplierLock = new object();
-        protected static IApplyEventsToStates EventApplier;
+        protected readonly IApplyEventsToStates EventApplier;
 
         protected BaseRepoSession(IHoldAllConfiguration configuration, IDisposable disposableHandle)
         {
@@ -40,16 +38,7 @@
 
             this.eventPublisher = configuration.EventPublisher;
 
-            if (EventApplier == null)
-            {
-                lock (eventApplierLock)
-                {
-                    if (EventApplier == null)
-                    {
-                        EventApplier = this.configuration.EventApplier;
-                    }
-                }
-            }
+            EventApplier = this.configuration.EventApplier;
         }
 
         public void AddEvents(IEnumerable<object> events)

--- a/src/BullOak.Repositories/StateEmit/BaseTypeFactory.cs
+++ b/src/BullOak.Repositories/StateEmit/BaseTypeFactory.cs
@@ -6,19 +6,10 @@
     using System.Linq.Expressions;
     using BullOak.Repositories.StateEmit.Emitters;
 
-    //public class FactoryAlreadyExistsException : Exception
-    //{
-    //    public FactoryAlreadyExistsException(string message)
-    //        :base(message)
-    //    { }
-    //}
-
     internal abstract class BaseTypeFactory : ICreateStateInstances
     {
         private ConcurrentDictionary<Type, WrapperCreationResult> WrapperFactories 
             = new ConcurrentDictionary<Type, WrapperCreationResult>();
-
-        private static BaseClassEmitter stateWrapper = new StateWrapperEmitter();
 
         public virtual void WarmupWith(IEnumerable<Type> typesToCreateFactoriesFor)
         {
@@ -73,7 +64,7 @@
                     };
             }
 
-            var wrapperType = StateTypeEmitter.EmitType(type, stateWrapper);
+            var wrapperType = StateTypeEmitter.EmitType(type, new StateWrapperEmitter());
 
             var ctor = wrapperType.GetConstructor(new[] { type });
 

--- a/src/BullOak.Repositories/StateEmit/EmittedTypeFactory.cs
+++ b/src/BullOak.Repositories/StateEmit/EmittedTypeFactory.cs
@@ -8,7 +8,6 @@
 
     internal class EmittedTypeFactory : BaseTypeFactory
     {
-        private static BaseClassEmitter ownedState = new OwnedStateClassEmitter();
         private ConcurrentDictionary<Type, Func<object>> TypeFactories = new ConcurrentDictionary<Type, Func<object>>();
 
         public override void WarmupWith(IEnumerable<Type> typesToCreateFactoriesFor)
@@ -43,7 +42,7 @@
 
         private static Func<object> CreateTypeFactoryMethod(Type type)
         {
-            var typeToCreate = type.IsInterface ? StateTypeEmitter.EmitType(type, ownedState) : type;
+            var typeToCreate = type.IsInterface ? StateTypeEmitter.EmitType(type, new OwnedStateClassEmitter()) : type;
 
             var ctor = typeToCreate.GetConstructor(Type.EmptyTypes);
 

--- a/src/BullOak.Repositories/StateEmit/Emitters/EmitHelper.cs
+++ b/src/BullOak.Repositories/StateEmit/Emitters/EmitHelper.cs
@@ -17,9 +17,9 @@
             return generator;
         }
 
-        public static ILGenerator ILEmit(this ILGenerator generator, OpCode code, MethodInfo fieldInfo)
+        public static ILGenerator ILEmit(this ILGenerator generator, OpCode code, MethodInfo methodInfo)
         {
-            generator.Emit(code, fieldInfo);
+            generator.Emit(code, methodInfo);
             return generator;
         }
     }

--- a/src/BullOak.Repositories/StateEmit/Emitters/OwnedStateClassEmitter.cs
+++ b/src/BullOak.Repositories/StateEmit/Emitters/OwnedStateClassEmitter.cs
@@ -1,10 +1,17 @@
 ﻿namespace BullOak.Repositories.StateEmit.Emitters
 {
+    using System;
     using System.Reflection;
     using System.Reflection.Emit;
 
     internal class OwnedStateClassEmitter : BaseClassEmitter
     {
+        public override Type EmitType(ModuleBuilder modelBuilder, Type typeToMake, string nameToUseForType = null) 
+            => base.EmitType(modelBuilder, typeToMake, "OwneddStateEmitter_" + (string.IsNullOrWhiteSpace(
+                                                                                       nameToUseForType)
+                                                                                       ? typeToMake.Name
+                                                                                       : nameToUseForType));
+
         private FieldBuilder fieldToStoreValue;
 
         public sealed override void ClassSetup(TypeBuilder typeBuilder)
@@ -12,9 +19,10 @@
         public sealed override void EmitCtor(TypeBuilder typeBuilder)
         { }
 
-        public sealed override void PropertySetup(TypeBuilder typeBuilder, PropertyInfo prop)
+        public sealed override void PropertySetup(TypeBuilder typeBuilder, PropertyInfo propInfo)
         {
-            fieldToStoreValue = typeBuilder.DefineField($"_{prop.Name}", prop.PropertyType, FieldAttributes.Private);
+            fieldToStoreValue = typeBuilder.DefineField($"_{propInfo.Name}", propInfo.PropertyType,
+                FieldAttributes.Public | FieldAttributes.HasDefault);
         }
 
         public sealed override void EmitGetValueOpCodes(ILGenerator getMethodGenerator)

--- a/src/BullOak.Repositories/StateEmit/Emitters/OwnedStateClassEmitter.cs
+++ b/src/BullOak.Repositories/StateEmit/Emitters/OwnedStateClassEmitter.cs
@@ -22,7 +22,7 @@
         public sealed override void PropertySetup(TypeBuilder typeBuilder, PropertyInfo propInfo)
         {
             fieldToStoreValue = typeBuilder.DefineField($"_{propInfo.Name}", propInfo.PropertyType,
-                FieldAttributes.Public | FieldAttributes.HasDefault);
+                FieldAttributes.Private | FieldAttributes.HasDefault);
         }
 
         public sealed override void EmitGetValueOpCodes(ILGenerator getMethodGenerator)

--- a/src/BullOak.Repositories/StateEmit/Emitters/StateTypeEmitter.cs
+++ b/src/BullOak.Repositories/StateEmit/Emitters/StateTypeEmitter.cs
@@ -7,7 +7,7 @@
     using System.Reflection.Emit;
     using System.Threading;
 
-    internal class StateTypeEmitter
+    internal static class StateTypeEmitter
     {
         private static int emittedIndex = 0;
 

--- a/src/BullOak.Repositories/StateEmit/Emitters/StateWrapperEmitter.cs
+++ b/src/BullOak.Repositories/StateEmit/Emitters/StateWrapperEmitter.cs
@@ -1,5 +1,6 @@
 ﻿namespace BullOak.Repositories.StateEmit.Emitters
 {
+    using System;
     using System.Reflection;
     using System.Reflection.Emit;
 
@@ -9,9 +10,16 @@
         private ConstructorBuilder constructorBuilder;
         private PropertyInfo property;
 
+        public override Type EmitType(ModuleBuilder modelBuilder, Type typeToMake, string nameToUseForType = null)
+            => base.EmitType(modelBuilder, typeToMake, "WrapperEmitter_" + (string.IsNullOrWhiteSpace(
+                                                           nameToUseForType)
+                                                           ? typeToMake.Name
+                                                           : nameToUseForType));
+
         public sealed override void ClassSetup(TypeBuilder typeBuilder)
         {
-            fieldToStoreValue = typeBuilder.DefineField($"_wrapped", InterfaceType, FieldAttributes.Private);
+            fieldToStoreValue = typeBuilder.DefineField($"_wrapped", InterfaceType,
+                FieldAttributes.Private | FieldAttributes.HasDefault);
         }
 
         public sealed override void EmitCtor(TypeBuilder typeBuilder)


### PR DESCRIPTION
Fixes #52 

Work done
---

  1. Major changes

Some classes had static fields which were designed under the assumption that configuration would only happen once at the start of the application and never happen again. This assumption is both wrong and also inhibits testing this using parallel runs (which is an important feature for consumers of this library (read developers using this)).

  2. Important things to review

- StateWrapperEmitter
- OwnedStateClassEmitter
- BaseRepoSession changed EventApplier to be readonly instance field.

Drawbacks?
---

This will affect warmup times negatively, lineraly proportional to number of configurations produced.

Integrity
---

- I have had a look on the PR preview for obvious whitespace\formatting issues before actually openned this PR:
 - [x] I have run unit tests
 - [x] I have run all acceptance tests
 - [x] I have run all integration tests
