### PR TITLE
BO-105: Avoid lock in applier retrieval if appliers exists already

### DIFF
--- a/src/BullOak.Repositories.Test.Acceptance/Specifications/ApplierSpecs.feature
+++ b/src/BullOak.Repositories.Test.Acceptance/Specifications/ApplierSpecs.feature
@@ -3,12 +3,12 @@
 	As a math idiot
 	I want to be told the sum of two numbers
 
-Scenario: Same applier processing multiple events of different type
+Scenario: Apply two events on cold-start works ok
 	Given an existing stream with 2 events
-	And a buyer name set event which can be upconverted as below in the stream
+	And a buyer name set event
 	| Title | Name  | Surname |
 	| Mr.   | Funny | Surname |
-	And a buyer name set event which can be upconverted as below in the stream
+	And a buyer name set event
 	| Title | Name  | Surname |
 	| Mr.   | Funny2 | Surname2 |
 	When I load my entity

--- a/src/BullOak.Repositories.Test.Acceptance/Specifications/ApplierSpecs.feature.cs
+++ b/src/BullOak.Repositories.Test.Acceptance/Specifications/ApplierSpecs.feature.cs
@@ -77,12 +77,12 @@ namespace BullOak.Repositories.Test.Acceptance.Specifications
             this.ScenarioTearDown();
         }
         
-        [Xunit.FactAttribute(DisplayName="Same applier processing multiple events of different type")]
+        [Xunit.FactAttribute(DisplayName="Apply two events on cold-start works ok")]
         [Xunit.TraitAttribute("FeatureTitle", "ApplierSpecs")]
-        [Xunit.TraitAttribute("Description", "Same applier processing multiple events of different type")]
-        public virtual void SameApplierProcessingMultipleEventsOfDifferentType()
+        [Xunit.TraitAttribute("Description", "Apply two events on cold-start works ok")]
+        public virtual void ApplyTwoEventsOnCold_StartWorksOk()
         {
-            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Same applier processing multiple events of different type", null, ((string[])(null)));
+            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Apply two events on cold-start works ok", null, ((string[])(null)));
 #line 6
 this.ScenarioInitialize(scenarioInfo);
             this.ScenarioStart();
@@ -98,7 +98,7 @@ this.ScenarioInitialize(scenarioInfo);
                         "Funny",
                         "Surname"});
 #line 8
- testRunner.And("a buyer name set event which can be upconverted as below in the stream", ((string)(null)), table1, "And ");
+ testRunner.And("a buyer name set event", ((string)(null)), table1, "And ");
 #line hidden
             TechTalk.SpecFlow.Table table2 = new TechTalk.SpecFlow.Table(new string[] {
                         "Title",
@@ -109,7 +109,7 @@ this.ScenarioInitialize(scenarioInfo);
                         "Funny2",
                         "Surname2"});
 #line 11
- testRunner.And("a buyer name set event which can be upconverted as below in the stream", ((string)(null)), table2, "And ");
+ testRunner.And("a buyer name set event", ((string)(null)), table2, "And ");
 #line 14
  testRunner.When("I load my entity", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line 15

--- a/src/BullOak.Repositories.Test.Acceptance/StepDefinitions/StreamSetupSteps.cs
+++ b/src/BullOak.Repositories.Test.Acceptance/StepDefinitions/StreamSetupSteps.cs
@@ -41,6 +41,7 @@
             sessionContainer.SaveStream(streamInfo.Id, combined.ToArray());
         }
 
+        [Given(@"a buyer name set event")]
         [Given(@"a buyer name set event which can be upconverted as below in the stream")]
         public void GivenABuyerNameSetEventWhichCanBeUpconvertedAsBelowInTheStream(Table table)
         {
@@ -53,7 +54,6 @@
             var originalEvents = sessionContainer.GetStream(streamInfo.Id);
             var combined = new List<ItemWithType>(originalEvents);
             combined.Add(new ItemWithType(@event));
-
 
             sessionContainer.SaveStream(streamInfo.Id, combined.ToArray());
         }

--- a/src/BullOak.Repositories/Appliers/EventApplier.cs
+++ b/src/BullOak.Repositories/Appliers/EventApplier.cs
@@ -71,13 +71,16 @@
 
             ApplierRetriever indexedApplier;
 
-            lock (indexedStateAppliers)
+            if (!indexedStateAppliers.TryGetValue(key, out indexedApplier))
             {
-                if (!indexedStateAppliers.TryGetValue(key, out indexedApplier))
+                lock (indexedStateAppliers)
                 {
-                    indexedApplier = GetApplierFromUnindexed(key);
+                    if (!indexedStateAppliers.TryGetValue(key, out indexedApplier))
+                    {
+                        indexedApplier = GetApplierFromUnindexed(key);
 
-                    indexedStateAppliers.Add(key, indexedApplier);
+                        indexedStateAppliers.Add(key, indexedApplier);
+                    }
                 }
             }
 


### PR DESCRIPTION
Fixes #105 

Work done
---

  1. Major changes

Instead of making applier a lock-free structure, I just followed the tried-and-tested if-lock-if pattern which works perfectly well on the longer term and is not as bug-prone as lock-free structures.

  2. Important things to review

Just the `EventApplier.cs` file and class.

Integrity
---

- [x] I have had a look on the PR preview for obvious whitespace\formatting issues before actually opened this PR
- [x] I have run unit tests
- [x] I have run all acceptance tests
- [x] I have run all integration tests
