### PR TITLE
EventStore repository to allow connection factory to be passed

### DIFF
--- a/src/BullOak.Repositories.EventStore.Test.Integration/Contexts/InProcEventStoreIntegrationContext.cs
+++ b/src/BullOak.Repositories.EventStore.Test.Integration/Contexts/InProcEventStoreIntegrationContext.cs
@@ -43,7 +43,7 @@
 
         public void SetupRepository(IHoldAllConfiguration configuration)
         {
-            repository = new EventStoreRepository<string, IHoldHigherOrder>(configuration, GetConnection());
+            repository = new EventStoreRepository<string, IHoldHigherOrder>(configuration, GetConnection);
         }
 
         [BeforeTestRun]

--- a/src/BullOak.Repositories.EventStore/EventStoreSession.cs
+++ b/src/BullOak.Repositories.EventStore/EventStoreSession.cs
@@ -73,7 +73,19 @@
 
         protected override void Dispose(bool disposing)
         {
-            if (disposing) { ConsiderSessionDisposed(); }
+            if (disposing)
+            {
+                ConsiderSessionDisposed();
+                try
+                {
+                    eventStoreConnection.Close();
+                    eventStoreConnection.Dispose();
+                }
+                catch
+                {
+                    // ignored as connection may already be in disposed state and throw
+                }
+            }
             base.Dispose(disposing);
         }
 
@@ -160,7 +172,9 @@
                 switchable.CanEdit = false;
             }
             else
+            {
                 @event = jobject.ToObject(type);
+            }
 
             return new ItemWithType(@event, type);
         }

--- a/src/BullOak.Repositories.EventStore/EventStoreSession.cs
+++ b/src/BullOak.Repositories.EventStore/EventStoreSession.cs
@@ -76,15 +76,8 @@
             if (disposing)
             {
                 ConsiderSessionDisposed();
-                try
-                {
-                    eventStoreConnection.Close();
-                    eventStoreConnection.Dispose();
-                }
-                catch
-                {
-                    // ignored as connection may already be in disposed state and throw
-                }
+                eventStoreConnection.SafeClose();
+
             }
             base.Dispose(disposing);
         }

--- a/src/BullOak.Repositories.EventStore/EventstoreConnectionExtensions.cs
+++ b/src/BullOak.Repositories.EventStore/EventstoreConnectionExtensions.cs
@@ -1,0 +1,26 @@
+﻿namespace BullOak.Repositories.EventStore
+{
+    using global::EventStore.ClientAPI;
+
+    public static class EventstoreConnectionExtensions
+    {
+        public static void SafeClose(this IEventStoreConnection connection)
+        {
+            try
+            {
+                if (connection == null)
+                {
+                    return;
+                }
+
+                connection.Close();
+                connection.Dispose();
+
+            }
+            catch
+            {
+                // ignored
+            }
+        }
+    }
+}

--- a/src/BullOak.Repositories.EventStore/EventstoreRepository.cs
+++ b/src/BullOak.Repositories.EventStore/EventstoreRepository.cs
@@ -42,7 +42,7 @@
                     throw new StreamNotFoundException(id.ToString());
                 }
 
-                var session = new EventStoreSession<TState>(configs, connectionFactory(), id.ToString());
+                var session = new EventStoreSession<TState>(configs, connection, id.ToString());
                 await session.Initialize();
 
                 return session;

--- a/src/BullOak.Repositories.EventStore/EventstoreRepository.cs
+++ b/src/BullOak.Repositories.EventStore/EventstoreRepository.cs
@@ -33,7 +33,7 @@
 
             if (connection == null)
             {
-                throw new RepositoryUnavailableException("Couldn't connect to the EvenStore repository. See InnerException for details", new ArgumentNullException(nameof(connection)));
+                throw new RepositoryUnavailableException("Couldn't connect to the EvenStore repository. Connection object is null.");
             }
 
             if (throwIfNotExists && !(await Contains(id, connection)))

--- a/src/BullOak.Repositories.EventStore/EventstoreRepository.cs
+++ b/src/BullOak.Repositories.EventStore/EventstoreRepository.cs
@@ -35,18 +35,15 @@
                 throw new RepositoryUnavailableException("Couldn't connect to the EvenStore repository. Connection object is null.");
             }
 
-            using (connection)
+            if (throwIfNotExists && !(await Contains(id, connection)))
             {
-                if (throwIfNotExists && !(await Contains(id, connection)))
-                {
-                    throw new StreamNotFoundException(id.ToString());
-                }
-
-                var session = new EventStoreSession<TState>(configs, connection, id.ToString());
-                await session.Initialize();
-
-                return session;
+                throw new StreamNotFoundException(id.ToString());
             }
+
+            var session = new EventStoreSession<TState>(configs, connection, id.ToString());
+            await session.Initialize();
+
+            return session;
         }
 
         private async Task<bool> Contains(TId selector, IEventStoreConnection connection)

--- a/src/BullOak.Repositories.EventStore/EventstoreRepository.cs
+++ b/src/BullOak.Repositories.EventStore/EventstoreRepository.cs
@@ -51,29 +51,11 @@
             }
             catch
             {
-                CleanupConnection(connection);
+                connection.SafeClose();
                 throw;
             }
 
             return session;
-        }
-
-        private void CleanupConnection(IEventStoreConnection connection)
-        {
-            try
-            {
-                if (connection == null)
-                {
-                    return;
-                }
-
-                connection.Close();
-                connection.Dispose();
-            }
-            catch
-            {
-                // ignored
-            }
         }
 
         private async Task<bool> Contains(TId selector, IEventStoreConnection connection)

--- a/src/BullOak.Repositories/Exceptions/RepositoryUnavailableException.cs
+++ b/src/BullOak.Repositories/Exceptions/RepositoryUnavailableException.cs
@@ -1,0 +1,20 @@
+﻿namespace BullOak.Repositories.Exceptions
+{
+    using System;
+
+    public class RepositoryUnavailableException : Exception
+    {
+        public RepositoryUnavailableException(string message) : base(message)
+        {
+
+        }
+
+
+        public RepositoryUnavailableException(string message, Exception innerException) : base(message, innerException)
+        {
+
+        }
+
+
+    }
+}


### PR DESCRIPTION
This change introduces connection factory method as a dependency to the EventStore repository instead of connection object to allow more flexibility with regards to how connection object is resolved. (e.g. to allow connection polling, re-connection and monitoring)


Work done
---

  1. Major changes

Changed 	`EventStoreRepository` constructor from
        `public EventStoreRepository(IHoldAllConfiguration configs, IEventStoreConnection connection)`
to	        
        `public EventStoreRepository(IHoldAllConfiguration configs, Func<IEventStoreConnection> connectionFactory)`

  2. Important things to review

`EventStoreRepository` as the method to create new session was changed

Integrity
---

- [x] I have had a look on the PR preview for obvious whitespace\formatting issues before actually openned this PR
- [x] I have run unit tests
- [x] I have run EventStore integration tests
