### PR TITLE
BO-112: Fixed unexpected error on tombstoned stream

### DIFF
--- a/src/BullOak.Repositories.EventStore.Test.Integration/BullOak.Repositories.EventStore.Test.Integration.csproj
+++ b/src/BullOak.Repositories.EventStore.Test.Integration/BullOak.Repositories.EventStore.Test.Integration.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net47</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
     <IsPackable>false</IsPackable>
     <EnableDefaultCompileItems>true</EnableDefaultCompileItems>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>

--- a/src/BullOak.Repositories.EventStore.Test.Integration/Contexts/InProcEventStoreIntegrationContext.cs
+++ b/src/BullOak.Repositories.EventStore.Test.Integration/Contexts/InProcEventStoreIntegrationContext.cs
@@ -95,6 +95,12 @@
             }
         }
 
+        public async Task SoftDeleteStream(Guid id)
+            => await repository.Delete(id.ToString());
+
+        public async Task HardDeleteStream(Guid id)
+            => await GetConnection().DeleteStreamAsync(id.ToString(), -1, true);
+
         public async Task<ResolvedEvent[]> ReadEventsFromStreamRaw(Guid id)
         {
             var conn = GetConnection();

--- a/src/BullOak.Repositories.EventStore.Test.Integration/Specification/ReconstituteState.feature
+++ b/src/BullOak.Repositories.EventStore.Test.Integration/Specification/ReconstituteState.feature
@@ -22,3 +22,25 @@ Scenario: Reconstitute state from one event stored using interface
 	When I load my entity
 	Then the load process should succeed
 	And HighOrder property should be 2
+
+Scenario: Reconstitute state from empty stream should succeed and return default state
+	Given a new stream
+	When I load my entity
+	Then the load process should succeed
+	And HighOrder property should be 0
+
+Scenario: Reconstitute state after a soft delete should succeed and return default state
+	Given a new stream
+	And 3 new events
+	And  I soft-delete the stream
+	When I load my entity
+	Then the load process should succeed
+	And HighOrder property should be 0
+
+Scenario: Reconstitute state after a hard delete should succeed and return default state
+	Given a new stream
+	And 3 new events
+	And  I hard-delete the stream
+	When I load my entity
+	Then the load process should succeed
+	And HighOrder property should be 0

--- a/src/BullOak.Repositories.EventStore.Test.Integration/Specification/ReconstituteState.feature.cs
+++ b/src/BullOak.Repositories.EventStore.Test.Integration/Specification/ReconstituteState.feature.cs
@@ -122,6 +122,74 @@ this.ScenarioSetup(scenarioInfo);
             this.ScenarioCleanup();
         }
         
+        [Xunit.FactAttribute(DisplayName="Reconstitute state from empty stream should succeed and return default state")]
+        [Xunit.TraitAttribute("FeatureTitle", "ReconstituteState")]
+        [Xunit.TraitAttribute("Description", "Reconstitute state from empty stream should succeed and return default state")]
+        public virtual void ReconstituteStateFromEmptyStreamShouldSucceedAndReturnDefaultState()
+        {
+            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Reconstitute state from empty stream should succeed and return default state", ((string[])(null)));
+#line 26
+this.ScenarioSetup(scenarioInfo);
+#line 27
+ testRunner.Given("a new stream", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
+#line 28
+ testRunner.When("I load my entity", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line 29
+ testRunner.Then("the load process should succeed", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line 30
+ testRunner.And("HighOrder property should be 0", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+            this.ScenarioCleanup();
+        }
+        
+        [Xunit.FactAttribute(DisplayName="Reconstitute state after a soft delete should succeed and return default state")]
+        [Xunit.TraitAttribute("FeatureTitle", "ReconstituteState")]
+        [Xunit.TraitAttribute("Description", "Reconstitute state after a soft delete should succeed and return default state")]
+        public virtual void ReconstituteStateAfterASoftDeleteShouldSucceedAndReturnDefaultState()
+        {
+            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Reconstitute state after a soft delete should succeed and return default state", ((string[])(null)));
+#line 32
+this.ScenarioSetup(scenarioInfo);
+#line 33
+ testRunner.Given("a new stream", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
+#line 34
+ testRunner.And("3 new events", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 35
+ testRunner.And("I soft-delete the stream", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 36
+ testRunner.When("I load my entity", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line 37
+ testRunner.Then("the load process should succeed", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line 38
+ testRunner.And("HighOrder property should be 0", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+            this.ScenarioCleanup();
+        }
+        
+        [Xunit.FactAttribute(DisplayName="Reconstitute state after a hard delete should succeed and return default state")]
+        [Xunit.TraitAttribute("FeatureTitle", "ReconstituteState")]
+        [Xunit.TraitAttribute("Description", "Reconstitute state after a hard delete should succeed and return default state")]
+        public virtual void ReconstituteStateAfterAHardDeleteShouldSucceedAndReturnDefaultState()
+        {
+            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Reconstitute state after a hard delete should succeed and return default state", ((string[])(null)));
+#line 40
+this.ScenarioSetup(scenarioInfo);
+#line 41
+ testRunner.Given("a new stream", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
+#line 42
+ testRunner.And("3 new events", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 43
+ testRunner.And("I hard-delete the stream", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 44
+ testRunner.When("I load my entity", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line 45
+ testRunner.Then("the load process should succeed", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line 46
+ testRunner.And("HighOrder property should be 0", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+            this.ScenarioCleanup();
+        }
+        
         [System.CodeDom.Compiler.GeneratedCodeAttribute("TechTalk.SpecFlow", "2.3.2.0")]
         [System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
         public class FixtureData : System.IDisposable

--- a/src/BullOak.Repositories.EventStore.Test.Integration/Specification/SaveEventStream.feature
+++ b/src/BullOak.Repositories.EventStore.Test.Integration/Specification/SaveEventStream.feature
@@ -48,3 +48,21 @@ Scenario: Saving already saved session should throw meaningful usage advice exce
 	And I try to save 'Session1'
 	Then the save process should fail for 'Session1'
 	And there should be 20 events in the stream
+
+Scenario: Write after a hard deleted stream should fail
+	Given a new stream
+	And 3 new events
+	And  I hard-delete the stream
+	And 10 new events
+	When I try to save the new events in the stream
+	Then the save process should fail
+
+Scenario: Write after a soft deleted stream should succeed
+	Given a new stream
+	And 3 new events
+	And  I soft-delete the stream
+	And 10 new events
+	When I try to save the new events in the stream
+	And I load my entity
+	Then the load process should succeed
+	And HighOrder property should be 9

--- a/src/BullOak.Repositories.EventStore.Test.Integration/Specification/SaveEventStream.feature.cs
+++ b/src/BullOak.Repositories.EventStore.Test.Integration/Specification/SaveEventStream.feature.cs
@@ -197,6 +197,58 @@ this.ScenarioSetup(scenarioInfo);
             this.ScenarioCleanup();
         }
         
+        [Xunit.FactAttribute(DisplayName="Write after a hard deleted stream should fail")]
+        [Xunit.TraitAttribute("FeatureTitle", "SaveEventsStream")]
+        [Xunit.TraitAttribute("Description", "Write after a hard deleted stream should fail")]
+        public virtual void WriteAfterAHardDeletedStreamShouldFail()
+        {
+            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Write after a hard deleted stream should fail", ((string[])(null)));
+#line 52
+this.ScenarioSetup(scenarioInfo);
+#line 53
+ testRunner.Given("a new stream", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
+#line 54
+ testRunner.And("3 new events", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 55
+ testRunner.And("I hard-delete the stream", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 56
+ testRunner.And("10 new events", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 57
+ testRunner.When("I try to save the new events in the stream", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line 58
+ testRunner.Then("the save process should fail", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line hidden
+            this.ScenarioCleanup();
+        }
+        
+        [Xunit.FactAttribute(DisplayName="Write after a soft deleted stream should succeed")]
+        [Xunit.TraitAttribute("FeatureTitle", "SaveEventsStream")]
+        [Xunit.TraitAttribute("Description", "Write after a soft deleted stream should succeed")]
+        public virtual void WriteAfterASoftDeletedStreamShouldSucceed()
+        {
+            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Write after a soft deleted stream should succeed", ((string[])(null)));
+#line 60
+this.ScenarioSetup(scenarioInfo);
+#line 61
+ testRunner.Given("a new stream", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
+#line 62
+ testRunner.And("3 new events", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 63
+ testRunner.And("I soft-delete the stream", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 64
+ testRunner.And("10 new events", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 65
+ testRunner.When("I try to save the new events in the stream", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line 66
+ testRunner.And("I load my entity", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 67
+ testRunner.Then("the load process should succeed", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line 68
+ testRunner.And("HighOrder property should be 9", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+            this.ScenarioCleanup();
+        }
+        
         [System.CodeDom.Compiler.GeneratedCodeAttribute("TechTalk.SpecFlow", "2.3.2.0")]
         [System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
         public class FixtureData : System.IDisposable

--- a/src/BullOak.Repositories.EventStore.Test.Integration/StepDefinitions/StreamStepsDefinitions.cs
+++ b/src/BullOak.Repositories.EventStore.Test.Integration/StepDefinitions/StreamStepsDefinitions.cs
@@ -80,11 +80,25 @@
                     testDataContext.LastGeneratedEvents));
         }
 
+        [Given(@"I soft-delete the stream")]
+        public async Task GivenISoft_DeleteTheStream()
+            => await eventStoreContainer.SoftDeleteStream(testDataContext.CurrentStreamId);
+
+        [Given(@"I hard-delete the stream")]
+        public async Task GivenIHard_DeleteTheStream()
+            => await eventStoreContainer.HardDeleteStream(testDataContext.CurrentStreamId);
+
         [Then(@"the load process should succeed")]
         [Then(@"the save process should succeed")]
         public void ThenTheSaveProcessShouldSucceed()
         {
             testDataContext.RecordedException.Should().BeNull();
+        }
+
+        [Then(@"the save process should fail")]
+        public void ThenTheSaveProcessShouldFail()
+        {
+            testDataContext.RecordedException.Should().NotBeNull();
         }
 
         [Then(@"there should be (.*) events in the stream")]
@@ -97,6 +111,8 @@
         [When(@"I load my entity")]
         public async Task WhenILoadMyEntity()
         {
+            if (testDataContext.RecordedException != null) return;
+
             testDataContext.RecordedException = await Record.ExceptionAsync(async () =>
             {
                 using (var session = await eventStoreContainer.StartSession(testDataContext.CurrentStreamId))

--- a/src/BullOak.Repositories.EventStore/BullOak.Repositories.EventStore.csproj
+++ b/src/BullOak.Repositories.EventStore/BullOak.Repositories.EventStore.csproj
@@ -12,9 +12,9 @@
     <RepositoryUrl>https://github.com/BullOak/BullOak</RepositoryUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/BullOak/BullOak/master/icons/Icon128.png</PackageIconUrl>
     <PackageTags>CQRS EventStourcing event-driven repository repositories DDD domain-driven-design</PackageTags>
-    <Version>2.1.0</Version>
-    <AssemblyVersion>2.1.0.0</AssemblyVersion>
-    <FileVersion>2.1.0.0</FileVersion>
+    <Version>2.1.1</Version>
+    <AssemblyVersion>2.1.1.0</AssemblyVersion>
+    <FileVersion>2.1.1.0</FileVersion>
     <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
     <NoWarn>NU5125</NoWarn>
   </PropertyGroup>

--- a/src/BullOak.Repositories.EventStore/EventStoreSession.cs
+++ b/src/BullOak.Repositories.EventStore/EventStoreSession.cs
@@ -63,6 +63,12 @@
                 do
                 {
                     currentSlice = await eventStoreConnection.ReadStreamEventsForwardAsync(streamName, nextSliceStart, SliceSize, false);
+                    if (currentSlice.Status == SliceReadStatus.StreamDeleted ||
+                        currentSlice.Status == SliceReadStatus.StreamNotFound)
+                    {
+                        currentVersion = -1;
+                        return result;
+                    }
                     nextSliceStart = currentSlice.NextEventNumber;
                     result.AddRange(currentSlice.Events);
                 } while (!currentSlice.IsEndOfStream);


### PR DESCRIPTION
Fixes #112 

Work done
---

  1. Major changes

Fixed arithmetic overflow exception when reading all events from a hard-deleted stream, by verifying that the stream is not deleted when loading all events in the stream.

To be honest, the behaviour is unexpected from EventStore and maybe could be filed as a bug since EventStore returns long.MaxValue as `LastEventNumber` but -1 for `NextEventNumber`

  2. Important things to review

The behavioural changes are super small and can be reviewed here: https://github.com/BullOak/BullOak/compare/master...skleanthous:BO-112?expand=1#diff-02746b43fabdb0f4edfe1a5f57339901

However, I added more tests to both do the debugging but also to document the behaviour to be expected when reading and writing both soft deleted and hard deleted streams. 

Integrity
---

- [x] I have had a look at the PR preview for obvious whitespace\formatting issues before actually opened this PR
- [x] I have run unit tests
- [x] I have run all acceptance tests
- [x] I have run all integration tests
