### PR TITLE
BO-118: Added metadata for ES integration, made event type simple name

### DIFF
--- a/src/BullOak.Repositories.EventStore/BullOak.Repositories.EventStore.csproj
+++ b/src/BullOak.Repositories.EventStore/BullOak.Repositories.EventStore.csproj
@@ -12,9 +12,9 @@
     <RepositoryUrl>https://github.com/BullOak/BullOak</RepositoryUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/BullOak/BullOak/master/icons/Icon128.png</PackageIconUrl>
     <PackageTags>CQRS EventStourcing event-driven repository repositories DDD domain-driven-design</PackageTags>
-    <Version>2.1.2</Version>
-    <AssemblyVersion>2.1.2.0</AssemblyVersion>
-    <FileVersion>2.1.2.0</FileVersion>
+    <Version>2.2.0</Version>
+    <AssemblyVersion>2.2.0.0</AssemblyVersion>
+    <FileVersion>2.2.0.0</FileVersion>
     <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
     <NoWarn>NU5125</NoWarn>
   </PropertyGroup>

--- a/src/BullOak.Repositories.EventStore/EventMetadata_V1.cs
+++ b/src/BullOak.Repositories.EventStore/EventMetadata_V1.cs
@@ -1,0 +1,19 @@
+﻿namespace BullOak.Repositories.EventStore
+{
+    using System;
+
+    public class EventMetadata_V1 : IHoldMetadata
+    {
+        public string EventTypeFQN { get; set; }
+        public int MetadataVersion { get; set; }
+
+        public EventMetadata_V1(string eventTypeFQN)
+        {
+            EventTypeFQN = eventTypeFQN ?? throw new ArgumentNullException(nameof(EventTypeFQN));
+            MetadataVersion = 1;
+        }
+
+        internal static EventMetadata_V1 From(ItemWithType @event)
+            => new EventMetadata_V1(@event.type.FullName);
+    }
+}

--- a/src/BullOak.Repositories.EventStore/IHoldMetadata.cs
+++ b/src/BullOak.Repositories.EventStore/IHoldMetadata.cs
@@ -1,0 +1,8 @@
+﻿namespace BullOak.Repositories.EventStore
+{
+    public interface IHoldMetadata
+    {
+        int MetadataVersion { get; set; }
+        string EventTypeFQN { get; set; }
+    }
+}

--- a/src/BullOak.Repositories.EventStore/MetadataException.cs
+++ b/src/BullOak.Repositories.EventStore/MetadataException.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Runtime.Serialization;
+using Newtonsoft.Json.Linq;
+
+namespace BullOak.Repositories.EventStore
+{
+    [Serializable]
+    internal class MetadataException : Exception
+    {
+        private JObject asJson;
+
+        public MetadataException(JObject asJson, string message)
+            : base(message)
+        {
+            this.asJson = asJson;
+        }
+    }
+}

--- a/src/BullOak.Repositories.EventStore/MetadataFactory.cs
+++ b/src/BullOak.Repositories.EventStore/MetadataFactory.cs
@@ -1,0 +1,20 @@
+﻿using Newtonsoft.Json.Linq;
+
+namespace BullOak.Repositories.EventStore
+{
+    using Newtonsoft.Json;
+
+    internal class MetadataFactory
+    {
+        internal static (IHoldMetadata metadata,int version) GetMetadataFrom(int metadataVersion, JObject asJson)
+        {
+            switch (metadataVersion)
+            {
+                case 1:
+                    return (asJson.ToObject<EventMetadata_V1>(), 1);
+                default:
+                    throw new MetadataException(asJson, $"Unrecognized Metadata Version: {metadataVersion}");
+            }
+        }
+    }
+}

--- a/src/BullOak.Repositories.EventStore/MetadataSerializer.cs
+++ b/src/BullOak.Repositories.EventStore/MetadataSerializer.cs
@@ -1,0 +1,23 @@
+﻿namespace BullOak.Repositories.EventStore
+{
+    using System.Text;
+    using Newtonsoft.Json;
+
+    internal static class MetadataSerializer
+    {
+        public static readonly Encoding Encoding = Encoding.UTF8;
+
+        public static byte[] Serialize(IHoldMetadata metadata)
+            => Encoding.GetBytes(JsonConvert.SerializeObject(metadata));
+
+        public static (IHoldMetadata metadata, int version) DeserializeMetadata(byte[] metadata)
+        {
+            var data = Encoding.GetString(metadata);
+            var asJson = Newtonsoft.Json.Linq.JObject.Parse(data);
+
+            var metadataVersion = asJson[nameof(IHoldMetadata.MetadataVersion)].ToObject<int>();
+
+            return MetadataFactory.GetMetadataFrom(metadataVersion, asJson);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #118 

Work done
---

1. Major changes

    1. Added versioned metadata to ES integration
    1. Made event type to be simple type name so as to be constant across versions for use by ES projections

2. Important things to review

Basically the ES Session and metadata serializer and class

Integrity
---

- [x] I have had a look on the PR preview for obvious whitespace\formatting issues before actually openned this PR
- [x] I have run unit tests
- [x] I have run all acceptance tests
- [x] I have run all integration tests
