### PR TITLE
Eventstore Client bumped up to v5.0.1

### DIFF
--- a/src/BullOak.Repositories.EventStore/BullOak.Repositories.EventStore.csproj
+++ b/src/BullOak.Repositories.EventStore/BullOak.Repositories.EventStore.csproj
@@ -12,9 +12,9 @@
     <RepositoryUrl>https://github.com/BullOak/BullOak</RepositoryUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/BullOak/BullOak/master/icons/Icon128.png</PackageIconUrl>
     <PackageTags>CQRS EventStourcing event-driven repository repositories DDD domain-driven-design</PackageTags>
-    <Version>2.2.0</Version>
-    <AssemblyVersion>2.2.0.0</AssemblyVersion>
-    <FileVersion>2.2.0.0</FileVersion>
+    <Version>2.2.1</Version>
+    <AssemblyVersion>2.2.1.0</AssemblyVersion>
+    <FileVersion>2.2.1.0</FileVersion>
     <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
     <NoWarn>NU5125</NoWarn>
   </PropertyGroup>
@@ -27,7 +27,7 @@
     <WarningsAsErrors />
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="EventStore.Client" Version="5.0.0" />
+    <PackageReference Include="EventStore.Client" Version="5.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Fixes ArgumentNullException thrown by EventStoreConnection

Work done
---

Bumped up EventStore.Client package to v5.0.1

Integrity
---

- [x] I have had a look on the PR preview for obvious whitespace\formatting issues before actually opened this PR
- [X ] I have run unit tests
- [ X] I have run all acceptance tests
- [X ] I have run all integration tests
