### PR TITLE
Upgrade tests projects to .NET Core 3.1

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,6 +12,9 @@ insert_final_newline = true
 [*.csproj]
 indent_size = 2
 
+[*.{yml,yaml}]
+indent_size = 2
+
 [*.md]
 trim_trailing_whitespace = false
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@
 #---------------------------------#
 
 # version format
-version: 1.0.{build}
+version: 2.6.{build}
 
 # you can use {branch} name in version format too
 # version: 1.0.{build}-{branch}
@@ -22,7 +22,7 @@ branches:
     - develop
 
 environment:
-  standard_version: "2.6.2"
+  standard_version: '2.6.2'
 
 # blacklist
 #  except:
@@ -67,7 +67,7 @@ max_jobs: 1
 #---------------------------------#
 
 # Build worker image (VM template)
-image: Visual Studio 2017
+image: Visual Studio 2019
 
 # scripts that are called at very beginning, before repo cloning
 #init:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,7 @@ branches:
     - develop
 
 environment:
-  standard_version: '2.6.1'
+  standard_version: "2.6.2"
 
 # blacklist
 #  except:

--- a/src/BullOak.Repositories.Test.Acceptance/BullOak.Repositories.Test.Acceptance.csproj
+++ b/src/BullOak.Repositories.Test.Acceptance/BullOak.Repositories.Test.Acceptance.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
       <IsPackable>false</IsPackable>
       <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
       <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
@@ -10,13 +10,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
-    <PackageReference Include="FluentAssertions" Version="5.9.0" />
-    <PackageReference Include="SpecFlow" Version="3.1.67" />
-    <PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.1.67" />
-    <PackageReference Include="SpecFlow.xUnit" Version="3.1.67" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="FluentAssertions" Version="5.10.3" />
+    <PackageReference Include="SpecFlow" Version="3.9.8" />
+    <PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.9.8" />
+    <PackageReference Include="SpecFlow.xUnit" Version="3.9.8" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BullOak.Repositories.Test.Unit.UpconverterContainer/BullOak.Repositories.Test.Unit.UpconverterContainer.csproj
+++ b/src/BullOak.Repositories.Test.Unit.UpconverterContainer/BullOak.Repositories.Test.Unit.UpconverterContainer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
       <IsPackable>false</IsPackable>
       <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
       <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
@@ -10,10 +10,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
-    <PackageReference Include="FluentAssertions" Version="5.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="FluentAssertions" Version="5.10.3" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BullOak.Repositories.Test.Unit/BullOak.Repositories.Test.Unit.csproj
+++ b/src/BullOak.Repositories.Test.Unit/BullOak.Repositories.Test.Unit.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
       <IsPackable>false</IsPackable>
       <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
       <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
@@ -10,11 +10,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FakeItEasy" Version="5.5.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
-    <PackageReference Include="FluentAssertions" Version="5.9.0" />
+    <PackageReference Include="FakeItEasy" Version="7.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="FluentAssertions" Version="5.10.3" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BullOak.Repositories/BullOak.Repositories.csproj
+++ b/src/BullOak.Repositories/BullOak.Repositories.csproj
@@ -31,9 +31,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Reflection.Emit" Version="4.6.0" />
-    <PackageReference Include="System.Reflection.Emit.ILGeneration" Version="4.6.0" />
-    <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.6.0" />
+    <PackageReference Include="System.Reflection.Emit" Version="4.7.0" />
+    <PackageReference Include="System.Reflection.Emit.ILGeneration" Version="4.7.0" />
+    <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
   </ItemGroup>
 
 </Project>

--- a/src/BullOak.Test.Benchmark/BullOak.Test.Benchmark.csproj
+++ b/src/BullOak.Test.Benchmark/BullOak.Test.Benchmark.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp2.2</TargetFramework>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
         <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
         <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
         <IsPackable>false</IsPackable>
@@ -11,8 +11,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="BenchmarkDotNet" Version="0.12.0" />
-        <PackageReference Include="BenchmarkDotNet.Annotations" Version="0.12.0" />
+        <PackageReference Include="BenchmarkDotNet" Version="0.13.0" />
+        <PackageReference Include="BenchmarkDotNet.Annotations" Version="0.13.0" />
+        <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
+        <PackageReference Include="System.CodeDom" Version="5.0.0" />
     </ItemGroup>
 
   <ItemGroup>

--- a/src/BullOak.Test.EndToEnd/BullOak.Test.EndToEnd.csproj
+++ b/src/BullOak.Test.EndToEnd/BullOak.Test.EndToEnd.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
       <IsPackable>false</IsPackable>
       <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
       <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
@@ -10,13 +10,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
-    <PackageReference Include="FluentAssertions" Version="5.9.0" />
-    <PackageReference Include="SpecFlow" Version="3.1.67" />
-    <PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.1.67" />
-    <PackageReference Include="SpecFlow.xUnit" Version="3.1.67" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="FluentAssertions" Version="5.10.3" />
+    <PackageReference Include="SpecFlow" Version="3.9.8" />
+    <PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.9.8" />
+    <PackageReference Include="SpecFlow.xUnit" Version="3.9.8" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes https://github.com/BullOak/BullOak/issues/143

Work done
---

* Upgraded tests project from `netcoreapp2.2` to `netcoreapp3.1`
* Upgraded nuget packages
* Upgraded CI build image from VS2017 to VS2019

Integrity
---

- [x] I have had a look on the PR preview for obvious whitespace\formatting issues before actually openned this PR
- [x] I have run unit tests
- [x] I have run all acceptance tests
- [x] I have run all integration tests
