### PR TITLE
test: Add test demonstrating record struct type emitter issue

### DIFF
--- a/src/BullOak.Repositories.Test.Unit/StateEmit/StateTypeEmitterTests.cs
+++ b/src/BullOak.Repositories.Test.Unit/StateEmit/StateTypeEmitterTests.cs
@@ -95,7 +95,7 @@
         }
 
         [Fact]
-        public void EmitType_OfInterfaceDerivingFromTwoInterfaceWithSameNamedButDifferntTypeProperty_ShouldImplementPropertiesExplicitly()
+        public void EmitType_OfInterfaceDerivingFromTwoInterfaceWithSameNamedButDifferentTypeProperty_ShouldImplementPropertiesExplicitly()
         {
             //Arrange
             var emitter = new OwnedStateClassEmitter();
@@ -110,6 +110,37 @@
             myType.Should().Implement(typeof(MyDerivedOfIntAndStringValues));
             myType.Should().Implement(typeof(MyBaseWithStringValue));
             myType.Should().Implement(typeof(MyBaseWithIntValue));
+        }
+
+        [Fact]
+        public void EmitType_OfInterfaceContainingRecordStruct_ShouldImplementProperties()
+        {
+            //Arrange
+            var emitter = new OwnedStateClassEmitter();
+            Type myType = null;
+
+            //Act
+            var exception = Record.Exception((Action) (() => myType = StateTypeEmitter.EmitType(typeof(MyBaseWithRecordStruct), emitter)));
+
+            //Assert
+            exception.Should().BeNull();
+            myType.Should().NotBeNull();
+            myType.Should().Implement(typeof(MyBaseWithRecordStruct));
+        }
+
+        [Fact]
+        public void EmitType_OfInterfaceContainingRecordStruct_ShouldImplementRecordStructSetter()
+        {
+            //Arrange
+            var emitter = new OwnedStateClassEmitter();
+            var myType = StateTypeEmitter.EmitType(typeof(MyBaseWithRecordStruct), emitter);
+            var instance = Activator.CreateInstance(myType) as MyBaseWithRecordStruct;
+
+            //Act
+            var exceptionSetter = Record.Exception((Action) (() => instance!.Times = new MyTimes(new TimeOnly(6, 0), new TimeOnly(18, 0))));
+
+            //Assert
+            exceptionSetter.Should().BeNull();
         }
     }
 }

--- a/src/BullOak.Repositories.Test.Unit/StateEmit/StateTypeEmitterTests.cs
+++ b/src/BullOak.Repositories.Test.Unit/StateEmit/StateTypeEmitterTests.cs
@@ -129,15 +129,15 @@
         }
 
         [Fact]
-        public void EmitType_OfInterfaceContainingRecordStruct_ShouldImplementRecordStructSetter()
+        public void EmitType_OfInterfaceWithGetSetProperty_ShouldImplementSetter()
         {
             //Arrange
             var emitter = new OwnedStateClassEmitter();
-            var myType = StateTypeEmitter.EmitType(typeof(MyBaseWithRecordStruct), emitter);
-            var instance = Activator.CreateInstance(myType) as MyBaseWithRecordStruct;
+            var myType = StateTypeEmitter.EmitType(typeof(MyBaseWithGetSet), emitter);
+            var instance = Activator.CreateInstance(myType) as MyBaseWithGetSet;
 
             //Act
-            var exceptionSetter = Record.Exception((Action) (() => instance!.Times = new MyTimes(new TimeOnly(6, 0), new TimeOnly(18, 0))));
+            var exceptionSetter = Record.Exception((Action) (() => instance!.Message = "yo!"));
 
             //Assert
             exceptionSetter.Should().BeNull();

--- a/src/BullOak.Repositories.Test.Unit/StateEmit/TestInterfaces.cs
+++ b/src/BullOak.Repositories.Test.Unit/StateEmit/TestInterfaces.cs
@@ -42,12 +42,12 @@ namespace BullOak.Repositories.Test.Unit.StateEmit
 
     public interface MyBaseWithGetSet
     {
-        public string Message { get; set; }
+        string Message { get; set; }
     }
 
     public interface MyBaseWithRecordStruct
     {
-        public MyTimes Times { get; set; }
+        MyTimes Times { get; set; }
     }
 
     public readonly record struct MyTimes(TimeOnly ReadyTime, TimeOnly CloseTime);

--- a/src/BullOak.Repositories.Test.Unit/StateEmit/TestInterfaces.cs
+++ b/src/BullOak.Repositories.Test.Unit/StateEmit/TestInterfaces.cs
@@ -1,4 +1,6 @@
-﻿namespace BullOak.Repositories.Test.Unit.StateEmit
+﻿using System;
+
+namespace BullOak.Repositories.Test.Unit.StateEmit
 {
     public interface MyInterface
     {
@@ -38,4 +40,10 @@
     {
     }
 
+    public interface MyBaseWithRecordStruct
+    {
+        public MyTimes Times { get; set; }
+    }
+
+    public readonly record struct MyTimes(TimeOnly ReadyTime, TimeOnly CloseTime);
 }

--- a/src/BullOak.Repositories.Test.Unit/StateEmit/TestInterfaces.cs
+++ b/src/BullOak.Repositories.Test.Unit/StateEmit/TestInterfaces.cs
@@ -40,6 +40,11 @@ namespace BullOak.Repositories.Test.Unit.StateEmit
     {
     }
 
+    public interface MyBaseWithGetSet
+    {
+        public string Message { get; set; }
+    }
+
     public interface MyBaseWithRecordStruct
     {
         public MyTimes Times { get; set; }

--- a/src/global.json
+++ b/src/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "6.0.100",
+    "rollForward": "latestFeature"
+  }
+}


### PR DESCRIPTION
When using state interface that contains get/set property of record struct type, setter throws an exception:

```
System.Exception' was thrown.
   at StateGen_OwneddStateEmitter_MyBaseWithRecordStruct.set_Times(MyTimes )
   at BullOak.Repositories.Test.Unit.StateEmit.StateTypeEmitterTests.<>c__DisplayClass8_0.<EmitType_OfInterfaceContainingRecordStruct_ShouldImplementRecordStructSetter>b__0()
```